### PR TITLE
Update edit_custom_walker.php

### DIFF
--- a/inc/edit_custom_walker.php
+++ b/inc/edit_custom_walker.php
@@ -145,7 +145,7 @@ class Walker_Nav_Menu_Edit_Custom extends Walker_Nav_Menu  {
 				</div>
 			</div>
 
-			<div class="menu-item-settings" id="menu-item-settings-<?php echo $item_id; ?>">
+			<div class="menu-item-settings wp-clearfix" id="menu-item-settings-<?php echo $item_id; ?>">
 				<?php if ( 'custom' == $item->type ) : ?>
 					<p class="field-url description description-wide">
 						<label for="edit-menu-item-url-<?php echo $item_id; ?>">


### PR DESCRIPTION
Menu item settings div doesn't contain floated contents.  Add "wp-clearfix" class to fix.
