### PR TITLE
Removed a condition that blocked deleting a field's value

### DIFF
--- a/inc/fields_actions.php
+++ b/inc/fields_actions.php
@@ -51,7 +51,7 @@ if( ! class_exists('acf_location_nav_menu_fields_actions') ) :
 					$field = acf_get_field( $k );
 					
 					// update field
-					if( $field && $v != '' ) {
+					if( $field ) {
 						
 						acf_update_value( $v, $item_id, $field );
 						


### PR DESCRIPTION
With that condition, if your field is a text input and you try to remove the text, the field doesn't get updated. 

I don't think removing the $v = '' will break anything. 